### PR TITLE
OnSpeed Gen3 display-serial input: native #4 wire, calibrated AOA bands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ We are working on several new features.
 - Display flight data in Knots, Standard, Metric, F or C
 - Designed for Raspberry Pi 4/5 but also runs on Mac OSx, Windows, and other linux systems.
 - Show NAV needles for approaches. (If NAV data is available)
-- Use multiple data input sources, (MGL, G3x, Dynon, GRT EIS, iLevil BOM, Stratux, Analog CDI via ADS1115, IMU BNO055 & BNO085, Generic Serial Logger, Joystick)
+- Use multiple data input sources, (MGL, G3x, Dynon, GRT EIS, iLevil BOM, Stratux, OnSpeed AOA, Analog CDI via ADS1115, IMU BNO055 & BNO085, Generic Serial Logger, Joystick)
 
 
 # Quick Start for Raspberry Pi and Mac OS

--- a/config_example.cfg
+++ b/config_example.cfg
@@ -65,6 +65,12 @@ screen = template:default.json
 #port = /dev/ttyS0
 #baudrate = 115200
 
+[serial_onspeedaoa]
+# set serial port for the OnSpeed Gen3 display-serial input
+# (the box's display UART, SERIALOUTFORMAT=ONSPEED, 115200 8N1)
+#port = /dev/ttyS0
+#baudrate = 115200
+
 [grt_eis]
 # set serial port for grt eis input
 #port = /dev/ttyS0

--- a/docs/efis_data.MD
+++ b/docs/efis_data.MD
@@ -57,6 +57,18 @@
 
   Garmin G3X EFIS Serial Protocol Link: https://drive.google.com/open?id=1uRRO-wdG7ya6_6-CfDVrZaKJsiYit-lm
 
+# OnSpeed Data
+
+  OnSpeed Gen3 emits its native display-serial stream (86-byte `#4` frames at 40 Hz, 115200 8N1) from the box's display UART — the same wire the OnSpeed M5Stack display consumes. It carries attitude, IAS, percent-lift AOA at tenths resolution, the aircraft's per-flap calibrated AOA band anchors (which drive the HUD AOA module's chevron/donut colors), flap position, VSI, OAT, G loads, G-onset rate, and deceleration rate.
+
+  OnSpeed Display Serial Protocol reference: https://dev.flyonspeed.org/reference/serial-protocol/
+
+  Requires OnSpeed firmware v4.25 or later with `SERIALOUTFORMAT=ONSPEED` (the default). The wire is versioned by its frame magic; older-firmware frames are dropped rather than mis-parsed.
+
+  Live: `python3 main.py --in1 serial_onspeedaoa` (set the port in config.cfg under `[serial_onspeedaoa]`). The default screen's HUD AOA and Slip Skid modules pick the data up directly; the OnSpeed extras are bindable from the screen editor as `airData[N].OnSpeed_*` fields.
+
+  Playback: any recording of the raw wire bytes plays back with `--in1 serial_onspeedaoa -e --playfile1 FILE.dat` — TronView's own data recorder writes one while flying, or capture the UART with any serial logger.
+
 # Stratux Data
 
   Recorded data for stratux is saved in the example data.  stratux_1.dat shows traffic near by.  Like 0.5 miles away.

--- a/lib/inputs/_onspeed_frame.py
+++ b/lib/inputs/_onspeed_frame.py
@@ -1,0 +1,370 @@
+# _onspeed_frame.py — OnSpeed `#4` display-serial frame codec (VENDORED).
+#
+# This file is a verbatim copy of `tools/onspeed_py/frame.py` from the
+# OnSpeed-Gen3 firmware repo (flyonspeed/OnSpeed-Gen3, PR #1152 lineage).
+# Do not hand-edit — refresh it wholesale from upstream when the wire
+# format changes.  Upstream CI byte-parity-tests this module against the
+# firmware's C++ encoder/decoder in both directions.
+#
+# Wire-format reference: https://dev.flyonspeed.org/reference/serial-protocol/
+#
+# The leading underscore keeps this file out of TronView's input-module
+# listing (lib/inputs/*.py without a leading underscore are selectable
+# inputs); `serial_onspeedaoa.py` imports from it.
+
+"""OnSpeed `#4` display-serial wire-frame builder and parser.
+
+Builds and parses the 86-byte ASCII frame (v4.25 size) that the
+firmware emits at 40 Hz and that `onspeed_core::ParseDisplayFrame`
+decodes on the M5 side. Single source of truth for the Python side of
+the wire — `tools/m5-replay/replay.py` and `tools/synth-record/`
+import `Frame` from here, and third-party consumers (e.g. TronView's
+`serial_onspeedaoa` input) vendor `parse_frame` + `FrameAccumulator`.
+
+The byte-for-byte contract lives in
+`software/Libraries/onspeed_core/src/proto/DisplaySerial.h`. Tests in
+`tools/onspeed_py/tests/` and `tools/m5-replay/test_replay.py`
+(Layer 2 round-trip) verify the firmware's `ParseDisplayFrame` accepts
+what `Frame.to_bytes()` emits; `test/test_host_main_cli/
+test_frame_parity.py` verifies `parse_frame` accepts what the C++
+`BuildDisplayFrame` emits.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+# Wire-format constants. Mirror onspeed_core/proto/DisplaySerial.h
+# (kDisplayFrameSizeBytes / kDisplayFrameChecksumLen).
+PAYLOAD_LEN = 82   # bytes 0..81 — ASCII fields through decelKtPerSec
+FRAME_LEN   = 86   # PAYLOAD_LEN + 2 hex CRC + CRLF
+MAGIC = "#4"   # display-frame wire version; mirrors
+               # onspeed_core/proto/DisplaySerial.h::kDisplayFrameMagic.
+               # The C++<->Python parity test (test/test_host_main_cli)
+               # fails CI if this drifts from the C++ constant.
+
+# IAS-invalid wire sentinel.  Mirrors `kIasInvalidWireSentinel` in
+# onspeed_core/proto/DisplaySerial.h: when the producer marks air-data
+# invalid, the iasKt %04u field carries 9999.  The M5 parser detects
+# this exact value, sets `iasIsValid=false` on the parsed frame, and
+# renders dashes for both IAS and percentLift.  Picked as the maximum
+# of the field width — far above any operational airspeed — so a
+# consumer that ignores `iasIsValid` still sees an obviously bogus
+# rather than a plausibly-low IAS reading.
+IAS_INVALID_WIRE_SENTINEL = 9999
+
+
+def _clamp_int(v: float, lo: int, hi: int) -> int:
+    """C-style truncation-toward-zero + clamp, matching SafeScaledInt."""
+    # ints are always finite; guarding the isfinite call keeps arbitrary-
+    # precision Python ints (beyond float range) from raising OverflowError
+    # on the float conversion inside math.isfinite.
+    if not isinstance(v, int) and not math.isfinite(v):
+        return 0
+    # int() in Python truncates toward zero, matching C's (int)cast.
+    i = int(v)
+    if i < lo:
+        return lo
+    if i > hi:
+        return hi
+    return i
+
+
+def _clamp_uint(v: float, lo: int, hi: int) -> int:
+    if not isinstance(v, int) and not math.isfinite(v):
+        return lo
+    i = int(v)
+    if i < lo:
+        return lo
+    if i > hi:
+        return hi
+    return i
+
+
+@dataclass
+class Frame:
+    """All fields transmitted in one `#4` payload (decel ×100, issue #776).
+
+    Field names and units mirror `DisplayBuildInputs` in
+    `onspeed_core/proto/DisplaySerial.h`.
+
+    Lateral G is BODY-FRAME (positive = airframe accelerating rightward),
+    matching `DisplayBuildInputs::lateralG` — the canonical convention,
+    shared with the SD log's `imuLateralG` and the WebSocket `lateralGLoad`.
+    The wire carries body-frame; slip-skid ball renderers (the M5 and the
+    LiveView slipBall) negate locally to draw ball-frame. The encoder below
+    scales `lateral_g * 1000` with no sign flip.
+
+    `percent_lift_pct` is in whole-percent units (0.0..99.9); the wire
+    encoder scales ×10 and truncates to int for the v4.23 `%03u` field
+    (range 0..999) — the wire still carries tenths-of-a-percent for
+    sub-pixel temporal smoothness, but every consumer surfaces a float.
+    The four band-edge percents (`tones_on_pct_lift`,
+    `onspeed_fast_pct_lift`, etc.) stay at integer percent (0..99);
+    they only move on detent or config-save events.
+
+    `pip_pct_lift` (v4.22+) is the visual L/Dmax pip percent — separated
+    from `tones_on_pct_lift` per PR #336.
+    """
+
+    pitch_deg:             float = 0.0
+    roll_deg:              float = 0.0
+    ias_kts:               float = 0.0
+    # Air-data validity flag.  Mirrors `DisplayBuildInputs::iasValid` in
+    # onspeed_core/proto/DisplaySerial.h.  When False, `to_bytes()`
+    # writes the IAS_INVALID_WIRE_SENTINEL (9999) into the iasKt field
+    # regardless of the `ias_kts` value, which the M5 parser uses to
+    # flip `iasIsValid=false` and render dashes for IAS and percentLift.
+    # Default True keeps live-mode and v2-log producers (all-numeric
+    # IAS) emitting the live value unchanged.
+    ias_valid:             bool  = True
+    palt_ft:               float = 0.0
+    turnrate_dps:          float = 0.0
+    lateral_g:             float = 0.0
+    vertical_g:            float = 1.0
+    percent_lift_pct:      float = 0.0  # whole percent (0.0..99.9); v4.23 wire encoder scales ×10 to tenths
+    vsi_fpm:               float = 0.0
+    oat_c:                 int   = 15
+    flightpath_deg:        float = 0.0
+    flap_deg:              int   = 0
+    tones_on_pct_lift:     int   = 0
+    onspeed_fast_pct_lift: int   = 0
+    onspeed_slow_pct_lift: int   = 0
+    stall_warn_pct_lift:   int   = 0
+    flaps_min_deg:         int   = 0
+    flaps_max_deg:         int   = 0
+    g_onset_rate:          float = 0.0
+    spin_cue:              int   = 0
+    data_mark:             int   = 0
+    pip_pct_lift:          int   = 0   # v4.22+, visual L/Dmax pip
+    sideslip_deg:          float = 0.0   # v4.25, body sideslip β (deg); lateral FPM input
+    decel_kt_per_sec:      float = 0.0   # v4.25, IAS deceleration rate (kt/s)
+
+    def to_bytes(self) -> bytes:
+        """Serialize to the 86-byte wire frame (payload + CRC + CRLF, v4.25).
+
+        Matches the printf format in
+        `onspeed_core/proto/DisplaySerial.cpp::BuildDisplayFrame`.
+        """
+        # Wire contract: when `ias_valid` is False, write
+        # IAS_INVALID_WIRE_SENTINEL (9999) into the iasKt %04u field.
+        # The M5 parser detects this exact value and flips
+        # `iasIsValid=false`, which the M5 firmware uses to render
+        # dashes for IAS and percentLift.  See iasValid contract in
+        # onspeed_core/proto/DisplaySerial.h.  Invalidity wins over
+        # the live `ias_kts` value — a defensively-set NaN with
+        # `ias_valid=True` still falls through `_clamp_uint`'s NaN
+        # branch (returns the lower clamp 0), but the canonical caller
+        # (live mode / v3 log replay) pairs NaN with `ias_valid=False`.
+        ias10_field = (
+            IAS_INVALID_WIRE_SENTINEL if not self.ias_valid
+            else _clamp_uint(self.ias_kts * 10, 0, 9999)
+        )
+        payload = (
+            MAGIC +
+            f"{_clamp_int(self.pitch_deg * 10, -999, 999):+04d}"
+            f"{_clamp_int(self.roll_deg * 10, -9999, 9999):+05d}"
+            f"{ias10_field:04d}"
+            f"{_clamp_int(self.palt_ft, -99999, 99999):+06d}"
+            f"{_clamp_int(self.turnrate_dps * 10, -9999, 9999):+05d}"
+            f"{_clamp_int(self.lateral_g * 1000, -999, 999):+04d}"
+            f"{_clamp_int(self.vertical_g * 10, -99, 99):+03d}"
+            f"{_clamp_uint(self.percent_lift_pct * 10.0, 0, 999):03d}"
+            f"{_clamp_int(self.vsi_fpm / 10, -999, 999):+04d}"
+            f"{_clamp_int(self.oat_c, -99, 99):+03d}"
+            f"{_clamp_int(self.flightpath_deg * 10, -999, 999):+04d}"
+            f"{_clamp_int(self.flap_deg, -99, 99):+03d}"
+            f"{_clamp_uint(self.tones_on_pct_lift, 0, 99):02d}"
+            f"{_clamp_uint(self.onspeed_fast_pct_lift, 0, 99):02d}"
+            f"{_clamp_uint(self.onspeed_slow_pct_lift, 0, 99):02d}"
+            f"{_clamp_uint(self.stall_warn_pct_lift, 0, 99):02d}"
+            f"{_clamp_int(self.flaps_min_deg, -99, 99):+03d}"
+            f"{_clamp_int(self.flaps_max_deg, -99, 99):+03d}"
+            f"{_clamp_int(self.g_onset_rate * 100, -999, 999):+04d}"
+            f"{_clamp_int(self.spin_cue, -9, 9):+02d}"
+            # dataMark WRAPS mod 100 (the pilot's counter increments without
+            # bound; the wire carries counter % 100).  Mirrors the C++
+            # `static_cast<unsigned>(in.dataMark) % 100u` — the 32-bit mask
+            # reproduces the unsigned cast over the full C++-representable
+            # domain, negatives included.
+            f"{(self.data_mark & 0xFFFFFFFF) % 100:02d}"
+            f"{_clamp_uint(self.pip_pct_lift, 0, 99):02d}"
+            f"{_clamp_int(self.sideslip_deg * 10, -999, 999):+04d}"
+            f"{_clamp_int(self.decel_kt_per_sec * 100, -999, 999):+04d}"
+        )
+        if len(payload) != PAYLOAD_LEN:
+            raise AssertionError(
+                f"payload length {len(payload)} != {PAYLOAD_LEN}: {payload!r}"
+            )
+        crc = sum(payload.encode("ascii")) & 0xFF
+        return f"{payload}{crc:02X}\r\n".encode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Parser — the inverse of Frame.to_bytes().
+#
+# Contract: accepts every frame `to_bytes()` (equivalently, per the CI
+# byte-parity test, the firmware's C++ BuildDisplayFrame) can emit;
+# returns None for everything else.  Deliberately STRICTER than the C++
+# ParseDisplayFrame at the margins: the payload must match the producer's
+# exact printf sign/width grammar (the C++ strtol-based field scan
+# tolerates some space-padded / sign-flexible variants) and the CRLF
+# terminator is required (the C++ one-shot parser never inspects it).
+# Extra strictness cannot reject a genuine frame, since the producer
+# grammar is exact.
+# ---------------------------------------------------------------------------
+
+# The producer's printf grammar, one named group per field, anchored to the
+# full 82-byte payload.  Group order matches the wire field order in
+# onspeed_core/proto/DisplaySerial.h.
+_PAYLOAD_RE = re.compile(
+    r"\A#4"
+    r"(?P<pitch10>[+-]\d{3})"       # pitchDeg        %+04d ×10
+    r"(?P<roll10>[+-]\d{4})"        # rollDeg         %+05d ×10
+    r"(?P<ias10>\d{4})"             # iasKt           %04u  ×10 (9999 = invalid sentinel)
+    r"(?P<palt>[+-]\d{5})"          # paltFt          %+06d ×1
+    r"(?P<turnrate10>[+-]\d{4})"    # turnRateDps     %+05d ×10
+    r"(?P<latg1000>[+-]\d{3})"      # lateralG        %+04d ×1000
+    r"(?P<vertg10>[+-]\d{2})"       # verticalG       %+03d ×10
+    r"(?P<pctlift10>\d{3})"         # percentLift     %03u  ×10 (tenths of a percent)
+    r"(?P<vsi10>[+-]\d{3})"         # vsiFpm10        %+04d (already fpm/10)
+    r"(?P<oat>[+-]\d{2})"           # oatC            %+03d ×1
+    r"(?P<fpa10>[+-]\d{3})"         # flightPathDeg   %+04d ×10
+    r"(?P<flaps>[+-]\d{2})"         # flapsDeg        %+03d ×1
+    r"(?P<tones>\d{2})"             # tonesOnPctLift  %02u
+    r"(?P<fast>\d{2})"              # onSpeedFastPctLift %02u
+    r"(?P<slow>\d{2})"              # onSpeedSlowPctLift %02u
+    r"(?P<warn>\d{2})"              # stallWarnPctLift   %02u
+    r"(?P<flapsmin>[+-]\d{2})"      # flapsMinDeg     %+03d ×1
+    r"(?P<flapsmax>[+-]\d{2})"      # flapsMaxDeg     %+03d ×1
+    r"(?P<gonset100>[+-]\d{3})"     # gOnsetRate      %+04d ×100
+    r"(?P<spin>[+-]\d)"             # spinRecoveryCue %+02d ×1
+    r"(?P<datamark>\d{2})"          # dataMark        %02u
+    r"(?P<pip>\d{2})"               # pipPctLift      %02u
+    r"(?P<sideslip10>[+-]\d{3})"    # sideslipDeg     %+04d ×10
+    r"(?P<decel100>[+-]\d{3})"      # decelKtPerSec   %+04d ×100
+    r"\Z"
+)
+
+
+def parse_frame(data: bytes) -> Optional[Frame]:
+    """Parse one `#4` wire frame; return None if it is not valid.
+
+    Mirrors `onspeed_core::ParseDisplayFrame`: at least FRAME_LEN bytes
+    (extra bytes beyond the first frame are ignored), `#4` magic, CRC over
+    bytes 0..81 matching the two hex digits at 82..83 (lowercase accepted,
+    as the C++ strtol does — the producer always emits uppercase), then
+    CRLF.
+
+    The returned `Frame` carries engineering units.  For the IAS-invalid
+    wire sentinel (iasKt field == 9999), `ias_valid` is False and
+    `ias_kts` keeps the raw decoded 999.9 — consumers must gate on
+    `ias_valid`, not on the number (same contract as the C++
+    `DisplayFrame::iasIsValid`).
+    """
+    if len(data) < FRAME_LEN:
+        return None
+    try:
+        payload = data[:PAYLOAD_LEN].decode("ascii")
+        crc_str = data[PAYLOAD_LEN:PAYLOAD_LEN + 2].decode("ascii")
+    except UnicodeDecodeError:
+        return None
+    if data[PAYLOAD_LEN + 2:FRAME_LEN] != b"\r\n":
+        return None
+    if not re.fullmatch(r"[0-9A-Fa-f]{2}", crc_str):
+        return None
+    if int(crc_str, 16) != sum(data[:PAYLOAD_LEN]) & 0xFF:
+        return None
+    m = _PAYLOAD_RE.match(payload)
+    if m is None:
+        return None
+
+    ias10 = int(m["ias10"])
+    return Frame(
+        pitch_deg=int(m["pitch10"]) / 10.0,
+        roll_deg=int(m["roll10"]) / 10.0,
+        ias_kts=ias10 / 10.0,
+        ias_valid=(ias10 != IAS_INVALID_WIRE_SENTINEL),
+        palt_ft=float(int(m["palt"])),
+        turnrate_dps=int(m["turnrate10"]) / 10.0,
+        lateral_g=int(m["latg1000"]) / 1000.0,
+        vertical_g=int(m["vertg10"]) / 10.0,
+        percent_lift_pct=int(m["pctlift10"]) / 10.0,
+        vsi_fpm=int(m["vsi10"]) * 10.0,
+        oat_c=int(m["oat"]),
+        flightpath_deg=int(m["fpa10"]) / 10.0,
+        flap_deg=int(m["flaps"]),
+        tones_on_pct_lift=int(m["tones"]),
+        onspeed_fast_pct_lift=int(m["fast"]),
+        onspeed_slow_pct_lift=int(m["slow"]),
+        stall_warn_pct_lift=int(m["warn"]),
+        flaps_min_deg=int(m["flapsmin"]),
+        flaps_max_deg=int(m["flapsmax"]),
+        g_onset_rate=int(m["gonset100"]) / 100.0,
+        spin_cue=int(m["spin"]),
+        data_mark=int(m["datamark"]),
+        pip_pct_lift=int(m["pip"]),
+        sideslip_deg=int(m["sideslip10"]) / 10.0,
+        decel_kt_per_sec=int(m["decel100"]) / 100.0,
+    )
+
+
+class FrameAccumulator:
+    """Byte-stream framing for the `#4` wire.
+
+    Mirrors `onspeed_core::DisplayFrameAccumulator::Inject` exactly:
+
+      * Any '#' byte resets to start-of-frame (a genuine payload never
+        contains '#', so this only fires on glitches / partial frames).
+      * Bytes before the first '#' are ignored.
+      * On the byte that fills FRAME_LEN, the frame parses only if that
+        byte is LF; the buffer resets either way.
+
+    At 40 Hz a consumer resynchronises within one frame (25 ms) of any
+    line disturbance.
+    """
+
+    def __init__(self) -> None:
+        self._buf = bytearray()
+
+    def reset(self) -> None:
+        self._buf.clear()
+
+    @property
+    def in_progress(self) -> bool:
+        return len(self._buf) > 0
+
+    def inject(self, byte: int) -> Optional[Frame]:
+        """Feed one byte; return a Frame on the byte that completes a
+        valid frame, else None."""
+        if byte == 0x23:                    # '#'
+            self._buf[:] = b"#"
+            return None
+        if not self._buf:
+            return None
+        self._buf.append(byte)
+        if len(self._buf) < FRAME_LEN:
+            return None
+        buf = bytes(self._buf)
+        self._buf.clear()
+        if byte != 0x0A:                    # LF must complete the frame
+            return None
+        return parse_frame(buf)
+
+    def feed(self, data: bytes) -> list[Frame]:
+        """Feed a chunk of bytes; return every frame completed within it.
+
+        Framing state carries across calls, so the stream may be
+        delivered in arbitrary chunk sizes.  A drain-and-keep-latest
+        consumer publishes `frames[-1]` when the list is non-empty.
+        """
+        frames = []
+        for b in data:
+            f = self.inject(b)
+            if f is not None:
+                frames.append(f)
+        return frames

--- a/lib/inputs/serial_onspeedaoa.py
+++ b/lib/inputs/serial_onspeedaoa.py
@@ -1,105 +1,246 @@
 #!/usr/bin/env python
 
+# Serial input source
+# OnSpeed Gen3 display-serial wire (`#4` framing, 86-byte frames at 40 Hz)
+#
+# Reads the native display-serial stream an OnSpeed Gen3 box emits from its
+# display UART (115200 8N1, one-way; the box default SERIALOUTFORMAT=ONSPEED).
+# This is the same wire the OnSpeed M5Stack secondary display consumes, so
+# TronView receives the box's full data set: attitude, IAS, percent-lift AOA,
+# the per-flap calibrated indexer band anchors, flap position/travel, VSI,
+# OAT, G loads, G-onset rate, deceleration rate, and the pilot's data-mark
+# counter.
+#
+# Wire-format reference: https://dev.flyonspeed.org/reference/serial-protocol/
+# Frame parser: vendored in _onspeed_frame.py (kept in sync with the
+# OnSpeed-Gen3 firmware repo, where it is byte-parity-tested against the
+# firmware's C++ encoder in CI).
+#
+# The wire is hard-versioned by its magic ("#4", OnSpeed firmware v4.25+).
+# A frame from older firmware fails the magic check and is dropped — the
+# display shows no data rather than mis-parsed data, by design.
+#
+# Values arrive PRE-SMOOTHED at 40 Hz — the box's own filter chain has
+# already run — so this input applies NO smoothing of its own (no moving
+# averages, no EMA).  Adding smoothing here would only add lag to a
+# stall-proximity cue.
+#
+# Read pattern: each readMessage() call drains everything the OS has
+# buffered, runs it all through the frame accumulator, and publishes the
+# most recent complete valid frame.  Bounded work per call, no backlog
+# growth, no flushInput() — the display always shows the newest frame even
+# when the input thread is visited slower than 40 Hz.
+
+from ._input import Input
+from ._onspeed_frame import FRAME_LEN, FrameAccumulator
+from lib import hud_utils
+from lib import hud_text
 import serial
 import time
-import struct
+from lib.common.dataship.dataship import Dataship
+from lib.common.dataship.dataship_imu import IMUData
+from lib.common.dataship.dataship_air import AirData
 
-class SerialParser:
-    def __init__(self, port='/dev/ttyS0', baudrate=115200):
-        self.ser = serial.Serial(
-            port=port,
-            baudrate=baudrate,
-            parity=serial.PARITY_NONE,
-            stopbits=serial.STOPBITS_ONE,
-            bytesize=serial.EIGHTBITS,
-            timeout=1,
-        )
-        self.serial_buffer = ''
-        self.serial_millis = time.time()
-        self.Pitch = 0.0
-        self.Roll = 0.0
-        self.IAS = 0.0
-        self.Palt = 0.0
-        self.TurnRate = 0.0
-        self.LateralG = 0.0
-        self.VerticalG = 0.0
-        self.PercentLift = 0
-        self.AOA = 0.0
-        self.iVSI = 0.0
-        self.OAT = 0
-        self.FlightPath = 0.0
-        self.FlapPos = 0
-        self.OnSpeedStallWarnAOA = 0.0
-        self.OnSpeedSlowAOA = 0.0
-        self.OnSpeedFastAOA = 0.0
-        self.OnSpeedTonesOnAOA = 0.0
-        self.gOnsetRate = 0.0
-        self.SpinRecoveryCue = 0
-        self.DataMark = 0
+KT_TO_MPH = 1.15078
+FRAME_PERIOD_S = 0.025  # 40 Hz wire cadence (kDisplayFramePeriodMs in the firmware)
 
-    def read_serial(self):
-        while True:
-            if self.ser.in_waiting > 0:
-                inChar = self.ser.read(1).decode('utf-8')
-                if inChar == '#':
-                    self.serial_buffer = inChar
-                    continue
 
-                if len(self.serial_buffer) > 80:
-                    self.serial_buffer = ''
-                    print("Serial data buffer overflow")
-                    continue
+class serial_onspeedaoa(Input):
+    def __init__(self):
+        self.name = "serial_onspeedaoa"
+        self.version = 2.0
+        self.inputtype = "serial"
+        self.accumulator = FrameAccumulator()
+        self.imuData = IMUData()
+        self.airData = AirData()
 
-                if self.serial_buffer:
-                    self.serial_buffer += inChar
+    def initInput(self, num, dataship: Dataship):
+        Input.initInput(self, num, dataship)  # call parent init Input.
 
-                    if len(self.serial_buffer) == 80 and self.serial_buffer[0] == '#' and self.serial_buffer[1] == '1' and inChar == '\n':
-                        # Calculate CRC
-                        calcCRC = sum([ord(c) for c in self.serial_buffer[:76]]) & 0xFF
-                        receivedCRC = int(self.serial_buffer[76:78], 16)
+        if(self.PlayFile != None and self.PlayFile != False):
+            # load playback file (raw #4 wire bytes).
+            if self.PlayFile == True:
+                defaultTo = "onspeed_aoa_1.dat"
+                self.PlayFile = hud_utils.readConfig(self.name, "playback_file", defaultTo)
+            self.ser, self.input_logFileName = Input.openLogFile(self, self.PlayFile, "rb")
+            self.isPlaybackMode = True
+        else:
+            self.efis_data_port = hud_utils.readConfig(self.name, "port", "/dev/ttyS0")
+            self.efis_data_baudrate = hud_utils.readConfigInt(self.name, "baudrate", 115200)
 
-                        if calcCRC == receivedCRC:
-                            self.parse_data()
-                            self.serial_millis = time.time()
-                        else:
-                            print("ONSPEED CRC Failed")
+            # open serial connection.
+            self.ser = serial.Serial(
+                port=self.efis_data_port,
+                baudrate=self.efis_data_baudrate,
+                parity=serial.PARITY_NONE,
+                stopbits=serial.STOPBITS_ONE,
+                bytesize=serial.EIGHTBITS,
+                timeout=1,
+            )
 
-    def parse_data(self):
-        self.Pitch = float(self.serial_buffer[2:6]) / 10
-        self.Roll = float(self.serial_buffer[6:11]) / 10
-        self.IAS = float(self.serial_buffer[11:15]) / 10
-        self.Palt = float(self.serial_buffer[15:21])
-        self.TurnRate = float(self.serial_buffer[21:26]) / 10
-        self.LateralG = float(self.serial_buffer[26:29]) / 100
-        self.VerticalG = float(self.serial_buffer[29:32]) / 10
-        self.PercentLift = int(self.serial_buffer[32:34])
-        self.AOA = float(self.serial_buffer[34:38]) / 10
-        self.iVSI = float(self.serial_buffer[38:42]) * 10
-        self.OAT = int(self.serial_buffer[42:45])
-        self.FlightPath = float(self.serial_buffer[45:49]) / 10
-        self.FlapPos = int(self.serial_buffer[49:52])
-        self.OnSpeedStallWarnAOA = float(self.serial_buffer[52:56]) / 10
-        self.OnSpeedSlowAOA = float(self.serial_buffer[56:60]) / 10
-        self.OnSpeedFastAOA = float(self.serial_buffer[60:64]) / 10
-        self.OnSpeedTonesOnAOA = float(self.serial_buffer[64:68]) / 10
-        self.gOnsetRate = float(self.serial_buffer[68:72]) / 100
-        self.SpinRecoveryCue = int(self.serial_buffer[72:74])
-        self.DataMark = int(self.serial_buffer[74:76])
+        # log raw wire bytes when recording.
+        self.output_logBinary = True
 
-        self.serial_buffer = ""
-        self.serial_process()
+        # create an imu object for attitude/rates/G from the box.
+        self.imuData = IMUData()
+        self.imuData.name = "onspeed_imu"
+        self.imuData.id = "onspeed_imu" + str(len(dataship.imuData))
+        dataship.imuData.append(self.imuData)
 
-    def serial_process(self):
-        if self.AOA == -100:
-            self.AOA = 0.0
+        # create an air object for IAS/alt/AOA/VSI/OAT + OnSpeed extras.
+        self.airData = AirData()
+        self.airData.name = "onspeed_air"
+        self.airData.id = "onspeed_air" + str(len(dataship.airData))
+        dataship.airData.append(self.airData)
 
-        # Add smoothing and processing logic as needed
-        # Example:
-        # self.SmoothedAOA = self.SmoothedAOA * aoaSmoothingAlpha + (1 - aoaSmoothingAlpha) * self.AOA
+        self.last_read_time = time.time()
+        # playback pacing state: frames are released against the wall
+        # clock at the wire's 40 Hz so a recording plays in real time
+        # regardless of how often the input thread visits.
+        self.playback_t0 = time.monotonic()
+        self.playback_frames = 0
 
-        # Print or process the parsed values
-        print(f"ONSPEED data: IAS {self.IAS:.2f}, Pitch {self.Pitch:.1f}, Roll {self.Roll:.1f}, LateralG {self.LateralG:.2f}, VerticalG {self.VerticalG:.2f}, Palt {self.Palt:.1f}, iVSI {self.iVSI:.1f}, AOA: {self.AOA:.1f}")
+    # close this data input
+    def closeInput(self, aircraft):
+        self.ser.close()
 
+    #############################################
+    ## Function: readMessage
+    # Drain whatever bytes are available, parse every complete frame,
+    # publish the most recent one.
+    def readMessage(self, dataship: Dataship):
+        if dataship.errorFoundNeedToExit:
+            return dataship
+        try:
+            if self.isPlaybackMode:
+                # release frames against the wall clock at the wire's
+                # 40 Hz, so the recording plays in real time no matter how
+                # often the input thread visits.
+                now = time.monotonic()
+                frames_due = int((now - self.playback_t0) / FRAME_PERIOD_S) - self.playback_frames
+                if frames_due <= 0:
+                    return dataship
+                if frames_due > 40:
+                    # long stall (suspend, blocked thread): rebase instead of
+                    # sprinting through the backlog.
+                    self.playback_t0 = now - 40 * FRAME_PERIOD_S
+                    self.playback_frames = 0
+                    frames_due = 40
+                data = self.ser.read(FRAME_LEN * frames_due)
+                self.playback_frames += frames_due
+                if len(data) == 0:
+                    self.ser.seek(0)  # loop the file.
+                    self.playback_t0 = now
+                    self.playback_frames = 0
+                    return dataship
+            else:
+                waiting = self.ser.in_waiting
+                # block (up to the port timeout) for the first byte, then
+                # take everything else the OS has buffered.
+                data = self.ser.read(waiting if waiting > 0 else 1)
+                if len(data) == 0:
+                    return dataship
+
+            frames = self.accumulator.feed(data)
+
+            if self.output_logFile != None:
+                Input.addToLog(self, self.output_logFile, data)
+
+            if not frames:
+                return dataship
+
+            # keep-latest: older frames in this chunk are superseded.
+            self.publish_frame(frames[-1])
+            self.airData.msg_count += len(frames)
+            self.imuData.msg_count += len(frames)
+
+            if dataship.debug_mode > 0:
+                current_time = time.time()
+                self.imuData.hz = round(len(frames) / max(current_time - self.last_read_time, 1e-6), 1)
+                self.last_read_time = current_time
+
+        except serial.serialutil.SerialException:
+            print("serial_onspeedaoa serial exception")
+            dataship.errorFoundNeedToExit = True
+        return dataship
+
+    #############################################
+    ## Function: publish_frame
+    # Write one parsed frame into the dataship objects.
+    def publish_frame(self, f):
+        self.imuData.pitch = f.pitch_deg
+        self.imuData.roll = f.roll_deg
+        self.imuData.turn_rate = f.turnrate_dps
+        self.imuData.vert_G = f.vertical_g
+        # The wire's lateralG is body-frame (positive = airframe
+        # accelerating rightward); the slip ball deflects opposite.  Negate
+        # here so slip_skid matches what the serial_g3x input produces for
+        # the same flight state (the Garmin wire carries the negated value)
+        # and the slipskid module renders identically from either source.
+        self.imuData.slip_skid = -f.lateral_g
+
+        air = self.airData
+        if f.ias_valid:
+            air.IAS = f.ias_kts * KT_TO_MPH
+            # percent-lift AOA, 0..100 — same semantic as the AOA percent
+            # the serial_g3x input reads from a Garmin wire, at tenths
+            # resolution.  0 below the box's audio-mute airspeed.
+            air.AOA = f.percent_lift_pct
+        else:
+            # air-data-invalid wire sentinel (on the ground, pitot inside
+            # the noise floor).  None renders as no-data.
+            air.IAS = None
+            air.AOA = None
+        # The wire carries pressure altitude; the box has no baro setting.
+        air.Alt_pres = f.palt_ft
+        air.Alt = f.palt_ft
+        air.BALT = f.palt_ft
+        air.VSI = f.vsi_fpm
+        air.OAT = (f.oat_c * 1.8) + 32  # c to f
+
+        # OnSpeed extras: the per-flap calibrated indexer band anchors
+        # (percent-lift units, snapped to the active flap detent — they
+        # re-anchor at every detent change, in lockstep with the box's
+        # audio cues), the visual L/Dmax pip, flap position/travel, and
+        # rate cues.  The hud/aoa module uses the anchors to draw the
+        # indexer bands from the aircraft's own calibration; everything
+        # here is also bindable from the screen editor.
+        air.OnSpeed_tonesOnPctLift = f.tones_on_pct_lift
+        air.OnSpeed_fastPctLift = f.onspeed_fast_pct_lift
+        air.OnSpeed_slowPctLift = f.onspeed_slow_pct_lift
+        air.OnSpeed_stallWarnPctLift = f.stall_warn_pct_lift
+        air.OnSpeed_pipPctLift = f.pip_pct_lift
+        air.OnSpeed_flapsDeg = f.flap_deg
+        air.OnSpeed_flapsMinDeg = f.flaps_min_deg
+        air.OnSpeed_flapsMaxDeg = f.flaps_max_deg
+        air.OnSpeed_gOnsetRate = f.g_onset_rate
+        air.OnSpeed_decelKtPerSec = f.decel_kt_per_sec
+        air.OnSpeed_dataMark = f.data_mark
+
+    #############################################
+    ## Function: printTextModeData
+    def printTextModeData(self, aircraft):
+        hud_text.print_header("Decoded data from Input Module: %s" % (self.name))
+        hud_text.print_object(aircraft)
+        hud_text.print_DoneWithPage()
+
+
+# Standalone smoke mode: open a port and print decoded frames.
+#   python3 -m lib.inputs.serial_onspeedaoa /dev/ttyUSB0
 if __name__ == "__main__":
-    parser = SerialParser()
-    parser.read_serial()
+    import sys
+
+    port = sys.argv[1] if len(sys.argv) > 1 else "/dev/ttyS0"
+    ser = serial.Serial(port=port, baudrate=115200, timeout=1)
+    acc = FrameAccumulator()
+    while True:
+        chunk = ser.read(ser.in_waiting or 1)
+        for f in acc.feed(chunk):
+            print(
+                f"ONSPEED: IAS {f.ias_kts:.1f}kt pctLift {f.percent_lift_pct:.1f}% "
+                f"pitch {f.pitch_deg:.1f} roll {f.roll_deg:.1f} flaps {f.flap_deg} "
+                f"bands {f.tones_on_pct_lift}/{f.onspeed_fast_pct_lift}/"
+                f"{f.onspeed_slow_pct_lift}/{f.stall_warn_pct_lift} pip {f.pip_pct_lift}"
+            )
+
+# vi: modeline tabstop=8 expandtab shiftwidth=4 softtabstop=4 syntax=python

--- a/lib/modules/hud/aoa/aoa.py
+++ b/lib/modules/hud/aoa/aoa.py
@@ -26,13 +26,80 @@ class aoa(Module):
         
      # called every redraw to adjust G3x AOA display using OnSpeed Profile
      # must adjust this array as needed for each Aircraft & AOA device
-    def adjust_aoa(self, aoa_value):
+    def adjust_aoa(self, aoa_value, e):
+        if aoa_value is None:
+            return 0
+        # When the air-data source carries the OnSpeed band anchors
+        # (serial_onspeedaoa input), the AOA percent is already the box's
+        # calibrated percent-lift and the bands are drawn from the same
+        # calibration — no remap needed.
+        if e["onspeed_anchors"]:
+            return aoa_value
         input_values = np.array([0, 50, 55, 60, 68, 79, 90, 99])
         output_values = np.array([0, 25, 39, 50, 59, 75, 85, 99])
-         
+
     # Interpolate to find the output value for the given input
         adjusted_value = np.interp(aoa_value, input_values, output_values)
         return adjusted_value
+
+    # Band edges driving the chevron/donut states below.  When the active
+    # air-data source carries the OnSpeed percent-lift anchors (the
+    # serial_onspeedaoa input publishes them), the edges come from the
+    # aircraft's own per-flap calibration and re-anchor live at every flap
+    # detent change, in lockstep with the box's audio cues.  Otherwise the
+    # legacy fixed values apply (G3X and other sources) and nothing changes.
+    # An OnSpeed box with no calibration yet publishes zero anchors, fails
+    # the validity gate below, and falls back to the legacy fixed bands —
+    # which are not meaningful for it either; calibrate the box first.
+    def band_edges(self):
+        a = self.airData
+        stall = getattr(a, "OnSpeed_stallWarnPctLift", None)
+        slow = getattr(a, "OnSpeed_slowPctLift", None)
+        fast = getattr(a, "OnSpeed_fastPctLift", None)
+        tones = getattr(a, "OnSpeed_tonesOnPctLift", None)
+        if (None not in (stall, slow, fast, tones)
+                and 0 < fast and tones <= fast < slow < stall):
+            mid = (fast + slow) / 2.0
+            quarter = (slow - fast) / 4.0
+            return {
+                "stall": stall, "slow": slow, "mid": mid, "fast": fast,
+                "tones": tones,
+                "dot_lo": mid - quarter, "dot_hi": mid + quarter,
+                "pip": getattr(a, "OnSpeed_pipPctLift", None),
+                "onspeed_anchors": True,
+            }
+        return {
+            "stall": 89, "slow": 68, "mid": 63, "fast": 54, "tones": 49,
+            "dot_lo": 57, "dot_hi": 63, "pip": None,
+            "onspeed_anchors": False,
+        }
+
+    # Percent-lift -> module-relative Y for the index bar and L/Dmax pip.
+    # With OnSpeed anchors this is the same piecewise-linear mapping the
+    # OnSpeed M5 display uses (mapPct2Display): linear from 0% to the
+    # donut's bottom edge (onSpeedFast), across the fixed donut band from
+    # fast to slow, then linear from the donut's top edge to the 99%
+    # lift-envelope ceiling.  The donut glyph never moves on screen; the
+    # bar and pip land inside it exactly when the aircraft is on speed,
+    # whatever the active detent's calibrated percents are.  Without
+    # anchors: plain linear (legacy behavior, paired with adjust_aoa's
+    # profile remap).
+    def pct_to_y(self, pct, e):
+        h = self.height
+        if not e["onspeed_anchors"]:
+            return ((100 - pct) * 0.01) * h
+        donut_bot = self.yCenter + self.centerCircleHeight
+        donut_top = self.yCenter - self.centerCircleHeight
+        fast, slow = e["fast"], e["slow"]
+        if pct <= 0:
+            return h
+        if pct <= fast:
+            return h - (h - donut_bot) * (pct / fast)
+        if pct <= slow:
+            return donut_bot - (donut_bot - donut_top) * ((pct - fast) / (slow - fast))
+        if pct <= 99:
+            return donut_top - donut_top * ((pct - slow) / (99.0 - slow))
+        return 0
 
     # called once for setup
     def initMod(self, pygamescreen, width=None, height=None):
@@ -80,15 +147,18 @@ class aoa(Module):
         x,y = pos
 
         # Get the current time in milliseconds
-        current_time = pygame.time.get_ticks()      
+        current_time = pygame.time.get_ticks()
+        # Band edges: aircraft's own calibration when OnSpeed anchors are
+        # present, legacy fixed values otherwise.
+        e = self.band_edges()
         # Call above AOA array data to adjust display for changing aoa input
-        adjusted_aoa = self.adjust_aoa(self.airData.AOA)
-        
+        adjusted_aoa = self.adjust_aoa(self.airData.AOA, e)
+
         # Define the flashing interval in milliseconds
         flash_interval = 500   # AOA Flash interval for dangerous AOA/stall condition
-          
+
         # AOA Graphic Color changes per AOA input
-        if self.airData.AOA is not None and self.airData.AOA > 89 and (current_time // flash_interval) % 2 == 0:
+        if self.airData.AOA is not None and self.airData.AOA > e["stall"] and (current_time // flash_interval) % 2 == 0:
             hud_graphics.hud_draw_circle(
                 self.pygamescreen, 
                 (127, 127, 127), # color Gray
@@ -124,7 +194,7 @@ class aoa(Module):
                 (x, y ),
                 8,
             )
-        elif self.airData.AOA is not None and self.airData.AOA > 68 and self.airData.AOA <= 89:
+        elif self.airData.AOA is not None and self.airData.AOA > e["slow"] and self.airData.AOA <= e["stall"]:
             hud_graphics.hud_draw_circle(
                 self.pygamescreen, 
                 ( 127, 127, 127), # color Gray
@@ -160,7 +230,7 @@ class aoa(Module):
                 (x, y ),
                 8,
             )
-        elif self.airData.AOA is not None and self.airData.AOA > 63 and self.airData.AOA <= 68:
+        elif self.airData.AOA is not None and self.airData.AOA > e["mid"] and self.airData.AOA <= e["slow"]:
             hud_graphics.hud_draw_circle(
                 self.pygamescreen, 
                 ( 0, 176, 80), # color Green
@@ -196,7 +266,7 @@ class aoa(Module):
                 (x, y ),
                 8,
             )
-        elif self.airData.AOA is not None and self.airData.AOA > 54 and self.airData.AOA <= 62:
+        elif self.airData.AOA is not None and self.airData.AOA > e["fast"] and self.airData.AOA <= e["mid"]:
             hud_graphics.hud_draw_circle(
                 self.pygamescreen, 
                 ( 0, 176, 80), # color Green
@@ -232,7 +302,7 @@ class aoa(Module):
                 (x, y ),
                 8,
             )
-        elif self.airData.AOA is not None and self.airData.AOA > 49 and self.airData.AOA <=54:
+        elif self.airData.AOA is not None and self.airData.AOA > e["tones"] and self.airData.AOA <= e["fast"]:
             hud_graphics.hud_draw_circle(
                 self.pygamescreen, 
                 (127, 127, 127), # color gray
@@ -309,24 +379,32 @@ class aoa(Module):
       #-------------------------------------------------
         if self.airData.AOA is not None and self.airData.AOA > 0:  #if self.showLDMax == True:if aircraft.aoa != None and aircraft.aoa > 0:
               # white circles L/D Max Dots. (Carson's Number)
+            # With OnSpeed anchors the dots sit at the box's visual L/Dmax
+            # pip percent (an aerodynamic reference that slides with the
+            # flap lever), on the same percent-to-screen mapping as the
+            # AOA bar; otherwise at the legacy fixed position.
+            if e["pip"] is not None:
+                yLDMax = self.pct_to_y(e["pip"], e)
+            else:
+                yLDMax = self.yLDMaxDots - 16
             hud_graphics.hud_draw_circle(
                 self.pygamescreen,
-                (255, 255, 255), 
-                (x+self.xCenter-self.xLDMaxDotsFromCenter, y - 16 + self.yLDMaxDots), 
-                6, 
+                (255, 255, 255),
+                (x+self.xCenter-self.xLDMaxDotsFromCenter, y + yLDMax),
+                6,
                 0,
             )
             hud_graphics.hud_draw_circle(
-                self.pygamescreen, 
-                (255, 255, 255), 
-                (x+self.xCenter+2+self.xLDMaxDotsFromCenter, y -16 + self.yLDMaxDots), 
-                6, 
+                self.pygamescreen,
+                (255, 255, 255),
+                (x+self.xCenter+2+self.xLDMaxDotsFromCenter, y + yLDMax),
+                6,
                 0,
             )
 
         #-------------------------------
             #draw Solid Center DOT when OnSpeed 
-            if self.airData.AOA is not None and self.airData.AOA > 57 and self.airData.AOA <63:
+            if self.airData.AOA is not None and self.airData.AOA > e["dot_lo"] and self.airData.AOA < e["dot_hi"]:
                 hud_graphics.hud_draw_circle(
                 self.pygamescreen, 
                 ( 0, 176, 80), # color Green
@@ -338,11 +416,12 @@ class aoa(Module):
             #  This function draws AOA indicator bar.
 
         if self.airData.AOA is not None and self.airData.AOA > 0:
+            bar_y = self.pct_to_y(adjusted_aoa, e)
             pygame.draw.line(
                 self.pygamescreen,
                 self.aoa_color,
-                (x-12, y + ((100-adjusted_aoa) * 0.01) * self.height),
-                (x+12+self.width, y + ((100-adjusted_aoa) * 0.01) * self.height),
+                (x-12, y + bar_y),
+                (x+12+self.width, y + bar_y),
                 5,
             )
 

--- a/util/run.sh
+++ b/util/run.sh
@@ -306,6 +306,7 @@ while $RUN_MENU_AGAIN; do
                                 "serial_d100" "Dynon D100 Serial" OFF \
                                 "serial_skyview" "Dynon Skyview Serial" OFF \
                                 "serial_g3x" "Garmin G3x Serial" OFF \
+                                "serial_onspeedaoa" "OnSpeed AOA Serial" OFF \
                                 "serial_grt_eis" "Grand Rapids EIS Serial" OFF \
                                 "serial_nmea" "NMEA Serial" OFF \
                                 "gyro_i2c_bno055" "BNO055 IMU i2c (Pi only)" OFF \


### PR DESCRIPTION
Adds a working input for the OnSpeed Gen3 box's **native display-serial wire** — the same 86-byte `#4` frames at 40 Hz that the OnSpeed M5Stack secondary display consumes — replacing the standalone `serial_onspeedaoa.py` scaffold (which parsed an older wire layout and predated the Dataship refactor; it defined `SerialParser` rather than the module class, so `--in1 serial_onspeedaoa` could not load it).

```
python3 main.py --in1 serial_onspeedaoa
```

(set the port under `[serial_onspeedaoa]` in config.cfg; also selectable from `util/run.sh` → Live Setup). With OnSpeed as the first input, the stock **default** and **EFIS_XL** screens' HUD AOA and Slip Skid modules pick the data up directly — no screen changes needed. Playback of any raw-wire recording works via `-e --playfile1 FILE.dat` (TronView's data recorder writes one while flying). The video below shows a recorded flight-test stall series playing back through this input: repeated deceleration runs to the stall break, with the AOA bands re-anchoring at the flap change.

## What the input publishes

- **IMUData**: pitch, roll, turn rate, vertical G, slip_skid (sign-matched to what `serial_g3x` produces, so the Slip Skid module renders identically from either source).
- **AirData**: IAS, pressure altitude, VSI, OAT, and `AOA` as the box's calibrated **percent-lift at tenths resolution** — same semantic as the AOA percent the G3X path reads, at 40 Hz.
- **OnSpeed extras** as editor-bindable `airData[N].OnSpeed_*` attributes: the per-flap calibrated AOA band anchors (`tonesOnPctLift`, `fastPctLift`, `slowPctLift`, `stallWarnPctLift`), the L/Dmax pip, flap position and travel range, G-onset rate, deceleration rate, and the pilot's data-mark counter.

Design notes: the box's signals arrive **pre-smoothed** from its own filter chain, so this input adds no smoothing (a moving average here would only add lag to a stall-proximity cue). Each `readMessage()` drains everything the OS has buffered through a resync-capable frame accumulator and publishes the newest complete valid frame — bounded work per visit, no backlog growth, and no `flushInput()`. When the wire flags air data invalid (on the ground), IAS/AOA publish as `None` rather than a bogus number.

## HUD AOA module: bands from the aircraft's own calibration

When the active air-data source carries the OnSpeed anchors, the chevron/donut band edges come from the aircraft's per-flap calibration and **re-anchor live at every flap detent change**, in lockstep with the OnSpeed box's audio cues — and the index bar + L/Dmax dots use the same piecewise percent-to-screen mapping as the OnSpeed M5 display (donut fixed on screen; each anchor lands on its glyph). `adjust_aoa`'s profile remap becomes a pass-through, since the percent is already calibrated.

**Sources without anchors (G3X, Skyview, MGL…) render exactly as before** — fixed bands, linear bar, profile remap — with one deliberate off-by-one fix: AOA in (62, 63] previously matched no band (the elif chain jumped `<= 62` → `> 63`) and fell to the no-cue gray state; the bands are now contiguous, so that sliver renders as the adjacent green-donut state.

## Wire format / compatibility

- Spec: https://dev.flyonspeed.org/reference/serial-protocol/ (115200 8N1 from the box's display UART; `SERIALOUTFORMAT=ONSPEED` is the box default).
- The wire is hard-versioned by its frame magic (`#4`, OnSpeed firmware **v4.25+**). Older-firmware frames fail the magic check and are dropped — no data rather than mis-parsed data.
- The frame parser is vendored verbatim in `lib/inputs/_onspeed_frame.py` from the OnSpeed-Gen3 repo, where it is byte-parity-tested against the firmware's C++ encoder in CI (flyonspeed/OnSpeed-Gen3#1152). When the wire format changes, we'll send a refresh PR with the new copy.
- OnSpeed has no magnetometer/GPS, so it publishes no heading — pair it with another input (e.g. a BNO IMU or GPS source) on screens that need yaw, per TronView's multi-input model.

Happy to adjust anything to house style — and glad to follow up with anything else this unlocks.